### PR TITLE
[PAGOPA-2426] fix(unzip): Use ByteArrayOutputStream instead of FileOutputStream

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-gpd-upload
 description: Microservice that handles file upload of massive debt positions JSON object
 type: application
-version: 0.113.0
-appVersion: 0.1.38
+version: 0.114.0
+appVersion: 0.1.39-skip-file-rewrite
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-upload
-    tag: "0.1.38"
+    tag: "0.1.39-skip-file-rewrite"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-upload
-    tag: "0.1.38"
+    tag: "0.1.39-skip-file-rewrite"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-gpd-upload
-    tag: "0.1.38"
+    tag: "0.1.39-skip-file-rewrite"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/openapi/openapi-support-internal.json
+++ b/openapi/openapi-support-internal.json
@@ -4,7 +4,7 @@
     "title": "GPD-Upload-Support-API",
     "description": "Microservice to manage PagoPA GPD Upload",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.1.38"
+    "version": "0.1.39-skip-file-rewrite"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "GPD-Upload-API",
     "description": "Microservice to manage PagoPA GPD Upload",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.1.38"
+    "version": "0.1.39-skip-file-rewrite"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>it.gov.pagopa.gpd.upload</groupId>
     <artifactId>pagopa-gpd-upload</artifactId>
-    <version>0.1.38</version>
+    <version>0.1.39-skip-file-rewrite</version>
     <packaging>${packaging}</packaging>
 
     <parent>

--- a/src/main/java/it/gov/pagopa/gpd/upload/service/BlobService.java
+++ b/src/main/java/it/gov/pagopa/gpd/upload/service/BlobService.java
@@ -66,16 +66,10 @@ public class BlobService {
     }
 
     public String upsert(String broker, String organizationFiscalCode, UploadOperation uploadOperation, CompletedFileUpload fileUpload) {
-        File file = this.unzip(fileUpload);
-        if (null == file)
-            throw new AppException(HttpStatus.BAD_REQUEST, "EMPTY FILE", "The JSON file is missing");
-        log.debug("File with name {} has been unzipped, upload operation: {}", file.getName(), uploadOperation);
-        try {
-            PaymentPositionsModel paymentPositionsModel = objectMapper.readValue(new FileInputStream(file), PaymentPositionsModel.class);
+        InputStream is = this.unzip(fileUpload);
 
-            if(!file.delete()) {
-                log.error("[Error][BlobService@upsert] The file {} was not deleted", file.getName());
-            }
+        try {
+            PaymentPositionsModel paymentPositionsModel = objectMapper.readValue(is, PaymentPositionsModel.class);
 
             if (!paymentPositionsValidator.isValid(paymentPositionsModel)) {
                 log.error("[Error][BlobService@upload] Debt-Positions validation failed for upload from broker {} and organization {}", broker, organizationFiscalCode);
@@ -91,8 +85,6 @@ public class BlobService {
             return upload(uploadInput, broker, organizationFiscalCode, paymentPositionsModel.getPaymentPositions().size());
         } catch (IOException e) {
             log.error("[Error][BlobService@upload] " + e.getMessage());
-            if(!file.delete())
-                log.error("[Error][BlobService@upsert] The file {} was not deleted", file.getName());
 
             if(e instanceof JsonMappingException)
                 throw new AppException(HttpStatus.BAD_REQUEST, "INVALID JSON", "Given JSON is invalid for required API payload: " + e.getMessage());
@@ -102,16 +94,10 @@ public class BlobService {
     }
 
     public String delete(String broker, String organizationFiscalCode, UploadOperation uploadOperation, CompletedFileUpload fileUpload) {
-        File file = this.unzip(fileUpload);
-        if (null == file)
-            throw new AppException(HttpStatus.BAD_REQUEST, "EMPTY FILE", "The JSON file is missing");
-        log.debug("File with name " + file.getName() + " has been unzipped");
-        try {
-            MultipleIUPDModel multipleIUPDModel = objectMapper.readValue(new FileInputStream(file), MultipleIUPDModel.class);
+        InputStream is = this.unzip(fileUpload);
 
-            if(!file.delete()) {
-                log.error(String.format("[Error][BlobService@delete] The file %s was not deleted", file.getName()));
-            }
+        try {
+            MultipleIUPDModel multipleIUPDModel = objectMapper.readValue(is, MultipleIUPDModel.class);
 
             if (!multipleIUPDValidator.isValid(multipleIUPDModel)) {
                 log.error(String.format("[Error][BlobService@delete] Debt-Positions validation failed for upload from broker %s and organization %s",
@@ -128,8 +114,6 @@ public class BlobService {
             return upload(uploadInput, broker, organizationFiscalCode, multipleIUPDModel.getPaymentPositionIUPDs().size());
         } catch (IOException e) {
             log.error("[Error][BlobService@upload] " + e.getMessage());
-            if(!file.delete())
-                log.error(String.format("[Error][BlobService@upsert] The file %s was not deleted", file.getName()));
 
             if(e instanceof JsonMappingException)
                 throw new AppException(HttpStatus.BAD_REQUEST, "INVALID JSON", "Given JSON is invalid for required API payload: " + e.getMessage());
@@ -176,80 +160,63 @@ public class BlobService {
         }
     }
 
-    private File unzip(CompletedFileUpload file) {
+    private InputStream unzip(CompletedFileUpload file) {
         int zipFiles = 0;
         int zipSize = 0;
-        File outputFile = null;
-        final byte[] buffer = new byte[1024];
 
-        if(!VALID_UPLOAD_EXTENSION.contains(getFileExtension(file.getFilename()))) {
-            log.error("[Error][BlobService@unzip] The file " + file.getFilename() + " with extension " + getFileExtension(file.getFilename()) + " is not a zip file ");
-            throw new AppException(HttpStatus.BAD_REQUEST, "NOT A ZIP FILE", "Only zip file can be uploaded.");
+        if (!VALID_UPLOAD_EXTENSION.contains(getFileExtension(file.getFilename()))) {
+            log.error("[Error][BlobService@unzip] Invalid extension: " + file.getFilename());
+            throw new AppException(HttpStatus.BAD_REQUEST, "NOT A ZIP FILE", "Only ZIP files can be uploaded.");
         }
 
-        try {
-            ZipInputStream zis = new ZipInputStream(file.getInputStream());
+        try (ZipInputStream zis = new ZipInputStream(file.getInputStream())) {
+            ZipEntry entry;
 
-            ZipEntry entry = zis.getNextEntry();
-            while (entry != null) {
+            while ((entry = zis.getNextEntry()) != null) {
                 zipFiles++;
                 if (zipFiles > zipMaxEntries) {
-                    zis.closeEntry();
-                    zis.close();
-                    log.error("[Error][BlobService@unzip] Zip content has too many entries");
-                    throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "Zip content has too many entries (check for hidden files)");
+                    log.error("[Error][BlobService@unzip] Too many entries in ZIP");
+                    throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "Too many entries in ZIP file.");
                 }
 
-                if (!entry.isDirectory()) {
-                    String fileName = entry.getName();
-
-                    // Validate file extension against whitelist
-                    if (!ALLOWABLE_EXTENSIONS.contains(getFileExtension(fileName))) {
-                        continue;
-                    }
-
-                    // Sanitize file name to remove potentially malicious characters
-                    String sanitizedFileName = sanitizeFileName(fileName);
-                    String sanitizedOutputPath = DESTINATION_DIRECTORY + File.separator + sanitizedFileName;
-
-                    // Disable auto-execution for extracted files
-                    outputFile = new File(sanitizedOutputPath);
-
-                    if (!outputFile.toPath().normalize().startsWith(DESTINATION_DIRECTORY)) {
-                        log.error("[Error][BlobService@unzip] Bad zip entry: the normalized file path does not start with the destination directory");
-                        throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "Bad zip entry");
-                    }
-
-                    boolean executableOff = outputFile.setExecutable(false);
-                    if(!executableOff) {
-                        log.error("[Error][BlobService@unzip] The underlying file system does not implement an execution permission and the operation failed.");
-                    }
-
-                    final FileOutputStream fos = new FileOutputStream(outputFile);
-                    int len;
-                    while ((len = zis.read(buffer)) > 0) {
-                        zipSize += len;
-                        if(zipSize > zipMaxSize) {
-                            zis.closeEntry();
-                            zis.close();
-                            fos.close();
-                            log.error("[Error][BlobService@unzip] Zip content too large");
-                            throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "Zip content too large");
-                        }
-
-                        fos.write(buffer, 0, len);
-                    }
-                    fos.close();
+                if (entry.isDirectory()) {
+                    continue; // Skip folders
                 }
-                entry = zis.getNextEntry();
+
+                String entryName = entry.getName();
+                if (!ALLOWABLE_EXTENSIONS.contains(getFileExtension(entryName))) {
+                    log.error("[Error][BlobService@unzip] Disallowed file type: " + entryName);
+                    throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "ZIP contains unsupported file type.");
+                }
+
+                // Read entry content into memory
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                byte[] buffer = new byte[4096];
+                int len;
+
+                while ((len = zis.read(buffer)) > 0) {
+                    zipSize += len;
+                    if (zipSize > zipMaxSize) {
+                        zis.closeEntry();
+                        zis.close();
+                        log.error("[Error][BlobService@unzip] ZIP file too large");
+                        throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "Unzipped content exceeds size limit.");
+                    }
+                    baos.write(buffer, 0, len);
+                }
+
+                // Return the first valid file as InputStream
+                zis.closeEntry();
+                zis.close();
+                log.debug("File with name " + file.getName() + " has been unzipped");
+                return new ByteArrayInputStream(baos.toByteArray());
             }
-            zis.closeEntry();
-            zis.close();
 
-            return outputFile;
+            log.error("[Error][BlobService@unzip] No valid file in ZIP");
+            throw new AppException(HttpStatus.BAD_REQUEST, "INVALID FILE", "No valid file found in ZIP.");
         } catch (IOException e) {
-            log.error("[Error][BlobService@unzip] " + e.getMessage());
-            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR", "Internal server error", e.getCause());
+            log.error("[Error][BlobService@unzip] " + e.getMessage(), e);
+            throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "UNZIP ERROR", "Could not unzip file", e);
         }
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Refactoring unzip method: does not write to application filesystem.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Bug when we have a Deployment with  `securityContext.readOnlyRootFilesystem: false`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
