### PR TITLE
fix: Get status or report for old upload statuses without serviceType

### DIFF
--- a/src/main/java/it/gov/pagopa/gpd/upload/service/StatusService.java
+++ b/src/main/java/it/gov/pagopa/gpd/upload/service/StatusService.java
@@ -30,7 +30,7 @@ public class StatusService {
         Status status = statusRepository.findStatusById(fileId, organizationFiscalCode);
         log.debug("[getStatus] status: " + status.getId());
 
-        if(Objects.equals(serviceType, status.getServiceType())){
+        if(status.getServiceType() == null || Objects.equals(serviceType, status.getServiceType())){
             return map(status);
         }
         throw new AppException(NOT_FOUND, "STATUS NOT FOUND", String.format("The Status for given fileId %s does not exist for %s", fileId, serviceType.name()));
@@ -39,7 +39,7 @@ public class StatusService {
     public UploadReport getReport(String orgFiscalCode, String fileId, ServiceType serviceType) {
         Status status = statusRepository.findStatusById(fileId, orgFiscalCode);
 
-        if(Objects.equals(serviceType, status.getServiceType())){
+        if(status.getServiceType() == null || Objects.equals(serviceType, status.getServiceType())){
             return mapReport(status);
         }
         throw new AppException(NOT_FOUND, "STATUS NOT FOUND", String.format("The Status for given fileId %s does not exist for %s", fileId, serviceType.name()));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Fixed problem when retrieving status or report of old upload statuses without serviceType

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
APIs were returning 404 when trying to retrieve statues or reports of old uploads saved without service type

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
