### PR TITLE
fix: [PAGOPA-3305] Improve Report serviceType segregation

### DIFF
--- a/src/main/java/it/gov/pagopa/gpd/upload/controller/external/UploadStatusController.java
+++ b/src/main/java/it/gov/pagopa/gpd/upload/controller/external/UploadStatusController.java
@@ -96,7 +96,7 @@ public class UploadStatusController {
             uploadReport = statusService.getReport(organizationFiscalCode, fileID, serviceType);
         } catch (AppException e) {
             if (e.getHttpStatus() == NOT_FOUND) {
-                uploadReport = blobService.getReport(brokerCode, organizationFiscalCode, fileID);
+                uploadReport = blobService.getReport(brokerCode, organizationFiscalCode, fileID, serviceType);
                 if (uploadReport == null)
                     throw e;
             }

--- a/src/main/java/it/gov/pagopa/gpd/upload/service/BlobService.java
+++ b/src/main/java/it/gov/pagopa/gpd/upload/service/BlobService.java
@@ -30,6 +30,8 @@ import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import static io.micronaut.http.HttpStatus.NOT_FOUND;
+
 @Singleton
 @Context
 @Slf4j
@@ -131,8 +133,12 @@ public class BlobService {
         }
     }
 
-    public UploadReport getReport(String broker, String fiscalCode, String uploadKey) {
+    public UploadReport getReport(String broker, String fiscalCode, String uploadKey, ServiceType serviceType) {
         BinaryData binaryDataReport = blobStorageRepository.downloadOutput(broker, fiscalCode, uploadKey);
+        ServiceType serviceTypeMetadata = blobStorageRepository.getBlobServiceTypeMetadata(broker, fiscalCode, uploadKey);
+        if (serviceType != serviceTypeMetadata) {
+            throw new AppException(NOT_FOUND, "REPORT NOT FOUND", "The Report for the given upload " + uploadKey + " does not exist in " + serviceType);
+        }
         try {
             return objectMapper.readValue(binaryDataReport.toString(), UploadReport.class);
         } catch (JsonProcessingException e) {

--- a/src/main/java/it/gov/pagopa/gpd/upload/utils/Constants.java
+++ b/src/main/java/it/gov/pagopa/gpd/upload/utils/Constants.java
@@ -1,0 +1,7 @@
+package it.gov.pagopa.gpd.upload.utils;
+
+public class Constants {
+    private Constants(){}
+
+    public static final String SERVICE_TYPE_METADATA = "serviceType";
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Improved Report segregation by serviceType

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The reports retrieved from the blob storage weren't segregated by serviceType, so the info was added to the blob metadata

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
